### PR TITLE
feat: Implement password management and fix participation issues

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -41,6 +41,7 @@
                 <h1 id="main-app-title">Gestor de excursiones del Colegio La Hispanidad</h1>
                 <div id="auth-status">
                     <span id="userInfoDisplay">Por favor, inicia sesión.</span>
+                    <button id="showChangePasswordModalBtn" class="button secondary" style="display: none; margin-left: 10px;">Cambiar Contraseña</button>
                     <button id="auth_button">Iniciar Sesión</button>
                     <button id="signout_button" style="display:none;">Cerrar Sesión</button>
                 </div>
@@ -251,5 +252,31 @@
     </div>
     <script src="app.js"></script>
     <script src="calendar.js"></script>
+
+    <div id="changePasswordModal" class="simple-modal" style="display: none;">
+        <div class="simple-modal-content">
+            <h4>Cambiar Contraseña</h4>
+            <form id="changePasswordForm">
+                <div>
+                    <label for="currentPassword">Contraseña Actual:</label>
+                    <input type="password" id="currentPassword" name="currentPassword" required>
+                </div>
+                <div>
+                    <label for="newPassword">Nueva Contraseña:</label>
+                    <input type="password" id="newPassword" name="newPassword" required minlength="8">
+                </div>
+                <div>
+                    <label for="confirmNewPassword">Confirmar Nueva Contraseña:</label>
+                    <input type="password" id="confirmNewPassword" name="confirmNewPassword" required minlength="8">
+                </div>
+                <div class="form-buttons">
+                    <button type="submit" class="success">Actualizar Contraseña</button>
+                    <button type="button" id="cancelChangePasswordBtn" class="secondary">Cancelar</button>
+                </div>
+                <p id="changePasswordError" class="error-message" style="margin-top: 10px;"></p>
+                <p id="changePasswordSuccess" class="success-message" style="margin-top: 10px;"></p>
+            </form>
+        </div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
This commit introduces several new features and bug fixes:

1.  Password Management:
    - You can now change your own password via a new modal in your settings area.
    - Administrators ('DIRECCION' role) can now change the passwords of other non-DIRECCION users through the admin user management interface. Appropriate authorization checks are in place to prevent misuse (e.g., admins changing other admins' passwords or their own via this form).

2.  Participation Modal Data Delay Fix:
    - I resolved an issue where the payment modal for excursion participations did not immediately reflect updated information. The UI (table and summary) now refreshes instantly after payment confirmation and data saving.

3.  Participation Deletion Modified to Reset:
    - The "delete" functionality for student participations in excursions has been changed. Instead of deleting the record, it now resets the participation status (authorization, payment, notes, assistance) to its initial default state. The UI has been updated to reflect this change (button text and confirmation messages).

All changes have been conceptually reviewed to ensure they meet the requirements and integrate correctly.