### PR TITLE
Fix: Resolve ReferenceError for 'mostrar todo' button in Alumnos view.

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1106,7 +1106,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 listaDeClasesGlobal.forEach(cl => htmlTablaAlumnos += `<option value="${cl.id}">${cl.nombre_clase}</option>`);
                 htmlTablaAlumnos += `</select></div>`;
             } else if (filtroClaseIdActual && currentUser.rol === 'DIRECCION') {
-                 htmlTablaAlumnos += `<button onclick="sessionStorage.removeItem('filtroAlumnosClaseId'); sessionStorage.removeItem('filtroAlumnosNombreClase'); loadAlumnos();" class="secondary" style="margin-bottom:15px;"><i class="fas fa-list-ul"></i> Mostrar Todos</button>`;
+                 htmlTablaAlumnos += `<button id="btnMostrarTodosAlumnosDynamic" class="secondary" style="margin-bottom:15px;"><i class="fas fa-list-ul"></i> Mostrar Todos</button>`;
             }
             if (currentUser.rol === 'DIRECCION' || (currentUser.rol === 'TUTOR' && currentUser.claseId)) {
                 htmlTablaAlumnos += `<button id="btnShowFormNuevoAlumno" class="success" style="margin-bottom:15px;"><i class="fas fa-user-plus"></i> Añadir Alumno</button>`;
@@ -1126,6 +1126,16 @@ document.addEventListener('DOMContentLoaded', () => {
             poblarSelectorClaseDestinoCSV(); 
             const formImp = document.getElementById('formImportarAlumnosCSV');
             if(formImp) formImp.addEventListener('submit', handleImportAlumnosCSV);
+
+            const btnMostrarTodosDynamic = document.getElementById('btnMostrarTodosAlumnosDynamic');
+            if (btnMostrarTodosDynamic) {
+                btnMostrarTodosDynamic.addEventListener('click', () => {
+                    sessionStorage.removeItem('filtroAlumnosClaseId');
+                    sessionStorage.removeItem('filtroAlumnosNombreClase');
+                    loadAlumnos();
+                });
+            }
+
             if(document.getElementById('btnShowFormNuevoAlumno')) document.getElementById('btnShowFormNuevoAlumno').onclick = () => showFormAlumno();
             alumnosContentDiv.querySelectorAll('.edit-alumno').forEach(b => b.onclick = async (e) => {
                 const alumnoId = e.target.dataset.id;


### PR DESCRIPTION
The 'mostrar todo' button in the Alumnos section was causing a 'loadAlumnos is not defined' JavaScript error. This was because the inline 'onclick' handler was trying to call a function that was not in the global scope.

This commit fixes the issue by:
1. Assigning a unique ID ('btnMostrarTodosAlumnosDynamic') to the 'mostrar todo' button when it's dynamically created in the `loadAlumnos` function in `public/app.js`.
2. Removing the inline 'onclick' attribute.
3. Programmatically adding an event listener to this button after it's added to the DOM. The event listener correctly clears the relevant session storage items for class filtering and then calls the `loadAlumnos` function to refresh the student list without filters.

This ensures the button works as intended, displays all students, and the class filter options remain available for you if you have the 'DIRECCION' role.